### PR TITLE
feat: add showMultidayEventsOnce option

### DIFF
--- a/MMM-CalendarExt3Agenda.css
+++ b/MMM-CalendarExt3Agenda.css
@@ -110,6 +110,13 @@
   gap: 5px;
 }
 
+.CX3A .cellBody .multiday {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 5px;
+}
+
 .CX3A .event .headline {
   display: flex;
   justify-content: flex-start;
@@ -140,14 +147,6 @@
   font-weight: bold;
 }
 
-.CX3A .cellBody .fullday .event > :not(.headline) {
-  display: none;
-}
-
-.CX3A .cellBody .fullday .event .headline :not(.title) {
-  display: none;
-}
-
 .CX3A.displayRepeatingCountTitle .cellBody .fullday .event {
   max-width: 100%;
 }
@@ -156,6 +155,41 @@
   overflow: visible;
   white-space: normal;
   text-overflow: clip;
+}
+
+.CX3A .cellBody .fullday .event > :not(.headline) {
+  display: none;
+}
+
+.CX3A .cellBody .fullday .event .headline :not(.title) {
+  display: none;
+}
+
+.CX3A .cellBody .multiday .event {
+  background-color: var(--calendarColor);
+  border-radius: 5px;
+  padding: 2px 5px;
+  display: block;
+  width: fit-content;
+  line-height: 100%;
+}
+
+.CX3A .cellBody .multiday .event .headline {
+  gap: 4px;
+}
+
+.CX3A .cellBody .multiday .event .title,
+.CX3A .cellBody .multiday .event .time,
+.CX3A .cellBody .multiday .event .symbol {
+  color: var(--oppositeColor);
+}
+
+.CX3A .cellBody .multiday .event .title {
+  font-weight: bold;
+}
+
+.CX3A .cellBody .multiday .event > :not(.headline) {
+  display: none;
 }
 
 .CX3A .cellWeather {

--- a/MMM-CalendarExt3Agenda.js
+++ b/MMM-CalendarExt3Agenda.js
@@ -46,6 +46,11 @@ Module.register('MMM-CalendarExt3Agenda', {
 
     skipDuplicated: true,
     relativeNamedDayStyle: "narrow", // "narrow" or "short" or "long"
+    showMultidayEventsOnce: false,
+    multidayRangeLabelOptions: {
+      month: 'short',
+      day: 'numeric'
+    },
   },
 
   defaulNotifications: {
@@ -385,22 +390,46 @@ Module.register('MMM-CalendarExt3Agenda', {
       let agenda = document.createElement('div')
       agenda.classList.add('agenda')
       dateIndex = dateIndex.sort((a, b) => a - b)
+      const viewStartTime = dateIndex[0] ?? null
+      const sameDate = (left, right) => {
+        return (
+          left.getFullYear() === right.getFullYear()
+          && left.getMonth() === right.getMonth()
+          && left.getDate() === right.getDate()
+        )
+      }
+      const getDisplayDayTime = (ev) => {
+        if (!(options.showMultidayEventsOnce && ev.isMultiday)) return null
+        const startDay = new Date(+ev.startDate)
+        const normalizedStartDay = new Date(startDay.getFullYear(), startDay.getMonth(), startDay.getDate()).getTime()
+        if (viewStartTime === null) return normalizedStartDay
+        // When the event started before the current view window, pin it to the first visible day.
+        return Math.max(normalizedStartDay, viewStartTime)
+      }
       for (const [i, date] of dateIndex.entries()) {
         let tm = new Date(date)
         let eotm = new Date(tm.getFullYear(), tm.getMonth(), tm.getDate(), 23, 59, 59, 999)
         let dayDom = makeCellDom(tm, i)
         let body = dayDom.getElementsByClassName('cellBody')[0]
-        let {fevs, sevs} = events.filter((ev) => {
+        let visibleEvents = events.filter((ev) => {
           return !(ev.endDate <= tm.getTime() || ev.startDate >= eotm.getTime())
-        }).reduce((result, ev) => {
-          const target = (ev.isFullday) ? result.fevs : result.sevs
+        }).filter((ev) => {
+          const displayDayTime = getDisplayDayTime(ev)
+          if (displayDayTime === null) return true
+          return sameDate(new Date(displayDayTime), tm)
+        })
+        let {mvs, fevs, sevs} = visibleEvents.reduce((result, ev) => {
+          const target = (options.showMultidayEventsOnce && ev.isMultiday)
+            ? result.mvs
+            : ((ev.isFullday) ? result.fevs : result.sevs)
           target.push(ev)
           return result
-        }, {fevs: [], sevs: []})
-        let eventCounts = fevs.length + sevs.length
+        }, {mvs: [], fevs: [], sevs: []})
+        let eventCounts = mvs.length + fevs.length + sevs.length
         dayDom.dataset.eventsCounts = eventCounts
+        if (eventCounts === 0 && options.onlyEventDays >= 1) continue
         if (eventCounts === 0) dayDom.classList.add('noEvents')
-        for (const [ key, value ] of Object.entries({ 'fullday': fevs, 'single': sevs })) {
+        for (const [ key, value ] of Object.entries({ 'multiday': mvs, 'fullday': fevs, 'single': sevs })) {
           let tDom = document.createElement('div')
           tDom.classList.add(key)
           for (let e of value) {
@@ -410,6 +439,8 @@ Module.register('MMM-CalendarExt3Agenda', {
               eventTimeOptions: options.eventTimeOptions,
               locale: options.locale,
               useIconify: options.useIconify,
+              showMultidayEventsOnce: options.showMultidayEventsOnce,
+              multidayRangeLabelOptions: options.multidayRangeLabelOptions,
             }, tm)
             tDom.appendChild(ev)
           }

--- a/README.md
+++ b/README.md
@@ -140,6 +140,8 @@ All the properties are omittable, and if omitted, a default value will be applie
 |`miniMonthTitleOptions` | { month: 'long', year: 'numeric' } | Title of month calendar (e.g. Aug. 2022) |
 |`miniMonthWeekdayOptions` | { weekday: 'short' } | A name of weekday of month calendar (e.g. Mon) |
 |`onlyEventDays` | 0 | `0` or `false` show empty days, `N:Integer bigger than 0` will show `N` days which have event(s) in that day.|
+|`showMultidayEventsOnce` | false | When `true`, each multiday event appears only once in the visible range (pinned to its first visible day) instead of repeating on every day it spans. |
+|`multidayRangeLabelOptions` | { month: 'short', day: 'numeric' } | Format for the date range label shown on a multiday event when `showMultidayEventsOnce` is enabled. See [Intl.DateTimeFormat options](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat/DateTimeFormat#parameters). |
 |`skipDuplicated` | true | On `true`, duplicated events(same title, same start/end) from any calendars will be skipped except one. |
 |`relativeNamedDayOptions`| { style: 'long' } | A name of the relative name (e.g. "Today" or "In 2 days" |
 


### PR DESCRIPTION
## Summary

Adds a `showMultidayEventsOnce` option (default `false`) that, when enabled, renders each multiday event in a dedicated `div.multiday` section only on the day it starts (or the first visible day in the view window). This prevents multiday events from repeating on every day they span.

## Changes

### JS
- Add `showMultidayEventsOnce: false` and `multidayRangeLabelOptions` defaults
- In `drawAgenda`: compute `viewStartTime`, add `sameDate()` and `getDisplayDayTime()` helpers
- Filter chain: first filter by day range, then filter multiday events to show only on their display day
- Reduce: `{fevs, sevs}` → `{mvs, fevs, sevs}` — multiday events get their own bucket
- Pass `showMultidayEventsOnce` and `multidayRangeLabelOptions` through to `renderEventAgenda`

### CSS
- Add `.CX3A .cellBody .multiday` container layout
- Style `.multiday .event` and `.single .event.multidayOnce` as pill-style blocks with calendar color background

### README
- Document `showMultidayEventsOnce` and `multidayRangeLabelOptions` in the config table

## Notes
- Timed multiday events already receive the `multidayOnce` class from CX3_Shared; this PR adds display infrastructure for fullday multiday events as well
- When `showMultidayEventsOnce: false` (default), behavior is identical to upstream